### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/kiefertaylorland/github-actions-ci-for-tests/security/code-scanning/1](https://github.com/kiefertaylorland/github-actions-ci-for-tests/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
